### PR TITLE
Fixed typo name of isOpertor() method to isOperator()

### DIFF
--- a/com/sc/project/scientificcalculator/ValueChecker.java
+++ b/com/sc/project/scientificcalculator/ValueChecker.java
@@ -8,6 +8,7 @@
  *                                     Added isCloseGrouper();
  *      December 9, 2023 - S. Cortel - Changed format for constants and enabled
  *                                      static access;
+ *      December 10, 2023 - S. Cortel - Fixed isOpertor() name to isOperator()
  *      
  * Purpose
  * 		
@@ -101,7 +102,7 @@ public class ValueChecker {
      * @param value to check in form of <code>char</code>
      * @return boolean
      */
-    public static boolean isOpertor(char value) {
+    public static boolean isOperator(char value) {
         return operators.contains(value);
     }
 
@@ -111,8 +112,8 @@ public class ValueChecker {
      * @param value to check in form of <code>String</code>
      * @return boolean
      */
-    public static boolean isOpertor(String value) {
-        return value.length() == 1 && isOpertor(value.charAt(0));
+    public static boolean isOperator(String value) {
+        return value.length() == 1 && isOperator(value.charAt(0));
     }
 
     /**

--- a/com/sc/project/scientificcalculator/tester/ValueCheckerTest.java
+++ b/com/sc/project/scientificcalculator/tester/ValueCheckerTest.java
@@ -6,7 +6,8 @@
  *      December 8, 2023 - S. Cortel - Changed method access to static;
  *                                     Added isOpenGrouper();
  *                                     Added isCloseGrouper();
- * 		December 9, 2023 - S. Cortel - Changed access to certain methods to static;		
+ * 		December 9, 2023 - S. Cortel - Changed access to certain methods to static;	
+ *      December 10, 2023 - S. Cortel - Fixed spelling of isOperator() method;	
  * 
  * Purpose
  * 		
@@ -185,37 +186,37 @@ public class ValueCheckerTest {
 
         input = 'r';
         expectedResult = true;
-        actualResult = ValueChecker.isOpertor(input);
+        actualResult = ValueChecker.isOperator(input);
         AssertUnit.assertEquals(expectedResult, actualResult, "isOperator() test 1");
 
         input = '/';
         expectedResult = true;
-        actualResult = ValueChecker.isOpertor(input);
+        actualResult = ValueChecker.isOperator(input);
         AssertUnit.assertEquals(expectedResult, actualResult, "isOperator() test 2");
 
         input = '(';
         expectedResult = false;
-        actualResult = ValueChecker.isOpertor(input);
+        actualResult = ValueChecker.isOperator(input);
         AssertUnit.assertEquals(expectedResult, actualResult, "isOperator() test 3");
 
         inputString = "r";
         expectedResult = true;
-        actualResult = ValueChecker.isOpertor(inputString);
+        actualResult = ValueChecker.isOperator(inputString);
         AssertUnit.assertEquals(expectedResult, actualResult, "isOperator() test 4");
 
         inputString = "/";
         expectedResult = true;
-        actualResult = ValueChecker.isOpertor(inputString);
+        actualResult = ValueChecker.isOperator(inputString);
         AssertUnit.assertEquals(expectedResult, actualResult, "isOperator() test 5");
 
         inputString = "(";
         expectedResult = false;
-        actualResult = ValueChecker.isOpertor(inputString);
+        actualResult = ValueChecker.isOperator(inputString);
         AssertUnit.assertEquals(expectedResult, actualResult, "isOperator() test 6");
 
         inputString = "1 + 1";
         expectedResult = false;
-        actualResult = ValueChecker.isOpertor(inputString);
+        actualResult = ValueChecker.isOperator(inputString);
         AssertUnit.assertEquals(expectedResult, actualResult, "isOperator() test 7");
     }
 


### PR DESCRIPTION
Fixed typo name of isOpertor() method to isOperator()